### PR TITLE
Fix constants bug for projects format string

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -48,7 +48,7 @@ DEFAULT_EVENT_FORMATS: dict[str, str] = {
     "project": "{sender[login]} {action} project {project[name]}",
     "project_column": "{sender[login]} {action} project column {project_column[name]}",
     "projects_v2": "{sender[login]} {action} project_v2 {projects_v2[title]}",
-    "projects_v2_item": "{sender[login]} {action} project item {project_v2_item[content_type]} for {projects_v2_item[content_node_id]}",  # noqa: E501
+    "projects_v2_item": "{sender[login]} {action} project item {projects_v2_item[content_type]} for {projects_v2_item[content_node_id]}",  # noqa: E501
     "projects_v2_status_update": "{sender[login]} {action} project status update",
     "public": "{sender[login]} publicized {repository[full_name]}",
     "pull_request": "{sender[login]} {action} pull #{pull_request[number]} in {repository[full_name]}",


### PR DESCRIPTION
# Description

fix typo in contants. the format string for projects_v2_item was wrong. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have run all ./script/* scripts and they pass
- [x] I have use pre-commit hook and it passes
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
